### PR TITLE
add constructor for pre-trained weights

### DIFF
--- a/src/Tinn/Tinn.csproj
+++ b/src/Tinn/Tinn.csproj
@@ -18,6 +18,7 @@
         <PackageIcon>icon.png</PackageIcon>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
         <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../../CHANGELOG.md"))</PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/src/Tinn/TinyNeuralNetwork.cs
+++ b/src/Tinn/TinyNeuralNetwork.cs
@@ -7,8 +7,6 @@ namespace Tinn;
 /// </summary>
 public class TinyNeuralNetwork
 {
-    internal float[] Weights;
-    internal float[] Biases;
     internal float[] HiddenLayer;
     internal float[] OutputLayer;
     internal int InputCount;
@@ -25,7 +23,7 @@ public class TinyNeuralNetwork
         int inputCount,
         int hiddenCount,
         int outputCount,
-        int seed)
+        int seed = default)
     {
         Random = new Random(seed);
         InputCount = inputCount;
@@ -42,15 +40,19 @@ public class TinyNeuralNetwork
     }
 
     /// <summary>
-    /// Creates an instance of an untrained neural network.
+    /// Creates an instance of a pre-trained neural network.
     /// </summary>
+    /// <param name="weights">Weights of the neural network.</param>
+    /// <param name="biases">Biases of the neural network.</param>
     /// <param name="inputCount">Number of inputs or features.</param>
     /// <param name="hiddenCount">Number of hidden neurons in a hidden layer.</param>
     /// <param name="outputCount">Number of outputs or classes.</param>
     public TinyNeuralNetwork(
+        float[] weights,
+        float[] biases,
         int inputCount,
         int hiddenCount,
-        int outputCount) : this(inputCount, hiddenCount, outputCount, seed: default)
+        int outputCount) : this(weights, biases, new float[hiddenCount], new float[outputCount], inputCount, default)
     {
     }
 
@@ -70,6 +72,15 @@ public class TinyNeuralNetwork
         Random = new Random(seed);
     }
 
+    /// <summary>
+    /// Gets the weights of the neural network.
+    /// </summary>
+    public float[] Weights { get; }
+
+    /// <summary>
+    /// Gets the biases of the neural network.
+    /// </summary>
+    public float[] Biases { get; }
 
     /// <summary>
     /// Loads a pre-trained neural network from a `*.tinn` file.

--- a/test/Tinn.Tests/SaveAndLoadTest.cs
+++ b/test/Tinn.Tests/SaveAndLoadTest.cs
@@ -22,4 +22,25 @@ public class SaveAndLoadTest
         // Assert
         loadedNetwork.Should().BeEquivalentTo(originalNetwork);
     }
+
+    [Theory, AutoData]
+    public void I_should_be_able_to_construct_from_existing_weights(
+        int inputCount,
+        int hiddenCount,
+        int outputCount)
+    {
+        // Arrange
+        var originalNetwork = new TinyNeuralNetwork(inputCount, hiddenCount, outputCount);
+
+        // Act
+        var newNetwork = new TinyNeuralNetwork(
+            originalNetwork.Weights,
+            originalNetwork.Biases,
+            inputCount,
+            hiddenCount,
+            outputCount);
+
+        // Assert
+        newNetwork.Should().BeEquivalentTo(originalNetwork);
+    }
 }


### PR DESCRIPTION
Also make weights and biases available as properties. This adds flexibility in how the network is persisted and reconstructed.
For example, I might want to serialize the weights and store in a database without involving the filesystem. With these changes it is now entirely up to the user how to deal with persisting the network.